### PR TITLE
Changed git to use https instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ versions of `nixpkgs` when needed.
 ### Instructions
 
 ```bash
-mise plugin install git@github.com/chadac/mise-nix
+mise plugin install https://github.com/chadac/mise-nix.git
 ```
 
 ## Usage


### PR DESCRIPTION
Hi! If someone doesn't have ssh configured for their github, this lets them copy-paste the instructions on the readme. 

If you could check to see if the https install works on your machine (with ssh configured as well), that would be appreciated!